### PR TITLE
Ambiq apollo4 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ bootloader/
 modules/
 tools/
 zephyr/
+env/
 #comment if you want to commit your model
 edge-impulse-sdk
 model-parameters/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,9 @@ add_definitions(-DEI_CLASSIFIER_TFLITE_ENABLE_CMSIS_NN=1
                 -DARM_MATH_LOOPUNROLL
                 )
 
+# If using Nordic boards, add the following definition
+# -DEI_NORDIC
+
 # Add the Edge Impulse SDK
 add_subdirectory(edge-impulse-sdk/cmake/zephyr)
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ This runs an exported impulse on most Zephyr development boards. See the documen
 
 This example has been tested on the following Zephyr targets:
 
-* [nrf52dk_nrf52832](https://docs.zephyrproject.org/latest/boards/arm/nrf52dk_nrf52832/doc/index.html)
-* [nrf52840dk_nrf52840](https://docs.zephyrproject.org/latest/boards/arm/nrf52840dk_nrf52840/doc/index.html)
-* [nrf5340dk_nrf5340_cpuapp](https://docs.zephyrproject.org/latest/boards/arm/nrf5340dk_nrf5340/doc/index.html)
-* [nrf9160dk_nrf9160](https://docs.zephyrproject.org/latest/boards/arm/nrf9160dk_nrf9160/doc/index.html)
+* [nrf52dk_nrf52832](https://docs.zephyrproject.org/latest/boards/nordic/nrf52dk/doc/index.html)
+* [nrf52840dk_nrf52840](https://docs.zephyrproject.org/latest/boards/nordic/nrf52840dk/doc/index.html)
+* [nrf5340dk_nrf5340_cpuapp](https://docs.zephyrproject.org/latest/boards/nordic/nrf5340dk/doc/index.html)
+* [nrf9160dk_nrf9160](https://docs.zephyrproject.org/latest/boards/nordic/nrf9160dk/doc/index.html)
 
 You can also run the example with Nordic nRF Connect SDK and the following boards:
 * [thingy91_nrf9160_ns](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/working_with_nrf/nrf91/thingy91.html#building-and-programming-from-the-source-code)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This runs an exported impulse on most Zephyr development boards. See the documen
 ## Tested on
 
 This example has been tested on the following Zephyr targets:
-
+* [apollo4p_blue_kxr_evb](https://docs.zephyrproject.org/latest/boards/ambiq/apollo4p_blue_kxr_evb/doc/index.html)
 * [nrf52dk_nrf52832](https://docs.zephyrproject.org/latest/boards/nordic/nrf52dk/doc/index.html)
 * [nrf52840dk_nrf52840](https://docs.zephyrproject.org/latest/boards/nordic/nrf52840dk/doc/index.html)
 * [nrf5340dk_nrf5340_cpuapp](https://docs.zephyrproject.org/latest/boards/nordic/nrf5340dk/doc/index.html)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,4 @@
-// Zpehyr 3.1.x and newer uses different include scheme
+// Zephyr 3.1.x and newer uses different include scheme
 #include <version.h>
 #if (KERNEL_VERSION_MAJOR > 3) || ((KERNEL_VERSION_MAJOR == 3) && (KERNEL_VERSION_MINOR >= 1))
 #include <zephyr/kernel.h>
@@ -7,7 +7,9 @@
 #endif
 #include "edge-impulse-sdk/classifier/ei_run_classifier.h"
 #include "edge-impulse-sdk/dsp/numpy.hpp"
+#ifdef EI_NORDIC
 #include <nrfx_clock.h>
+#endif
 
 static const float features[] = {
     // copy raw features here (for example from the 'Live classification' page)
@@ -23,7 +25,7 @@ int main() {
     // This is needed so that output of printf is output immediately without buffering
     setvbuf(stdout, NULL, _IONBF, 0);
 
-#ifdef CONFIG_SOC_NRF5340_CPUAPP
+#ifdef CONFIG_SOC_NRF5340_CPUAPP // this cones from Zephyr
     // Switch CPU core clock to 128 MHz
     nrfx_clock_divider_set(NRF_CLOCK_DOMAIN_HFCLK, NRF_CLOCK_HFCLK_DIV_1);
 #endif
@@ -45,7 +47,7 @@ int main() {
         features_signal.get_data = &raw_feature_get_data;
 
         // invoke the impulse
-        EI_IMPULSE_ERROR res = run_classifier(&features_signal, &result, true);
+        EI_IMPULSE_ERROR res = run_classifier(&features_signal, &result, false);
         printk("run_classifier returned: %d\n", res);
 
         if (res != 0) return 1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,7 +25,7 @@ int main() {
     // This is needed so that output of printf is output immediately without buffering
     setvbuf(stdout, NULL, _IONBF, 0);
 
-#ifdef CONFIG_SOC_NRF5340_CPUAPP // this cones from Zephyr
+#ifdef CONFIG_SOC_NRF5340_CPUAPP // this comes from Zephyr
     // Switch CPU core clock to 128 MHz
     nrfx_clock_divider_set(NRF_CLOCK_DOMAIN_HFCLK, NRF_CLOCK_HFCLK_DIV_1);
 #endif


### PR DESCRIPTION
Apollo4 works almost out of the box, except the nordic-specific stuff in main.cpp

I moved the nordic-specific things behind a flag and removed double result print by disabling the debug mode of run_classifier