### PR TITLE
add nRF54L15dk and move to ncs 3.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 WORKDIR /app
 
@@ -34,7 +34,7 @@ RUN python3 -m pip install pip==21.2.4
 RUN pip3 install west==1.0.0
 RUN pip3 install ecdsa==0.17.0
 RUN mkdir /ncs
-RUN cd /ncs && west init -m https://github.com/nrfconnect/sdk-nrf --mr v2.4.0
+RUN cd /ncs && west init -m https://github.com/nrfconnect/sdk-nrf --mr v3.0.0
 RUN cd /ncs && west update
 RUN cd /ncs && west zephyr-export
 RUN pip3 install -r /ncs/zephyr/scripts/requirements.txt

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This example has been tested on the following Zephyr targets:
 * [nrf52840dk_nrf52840](https://docs.zephyrproject.org/latest/boards/nordic/nrf52840dk/doc/index.html)
 * [nrf5340dk_nrf5340_cpuapp](https://docs.zephyrproject.org/latest/boards/nordic/nrf5340dk/doc/index.html)
 * [nrf9160dk_nrf9160](https://docs.zephyrproject.org/latest/boards/nordic/nrf9160dk/doc/index.html)
+* [nrf54l15dk/nrf54l15/cpuapp](https://docs.zephyrproject.org/latest/boards/nordic/nrf54l15dk/doc/index.html)
+  * NCS 3.0.0: `west build -b nrf54l15dk/nrf54l15/cpuapp`
 
 You can also run the example with Nordic nRF Connect SDK and the following boards:
 * [thingy91_nrf9160_ns](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/working_with_nrf/nrf91/thingy91.html#building-and-programming-from-the-source-code)

--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ This runs an exported impulse on most Zephyr development boards. See the documen
 ## Tested on
 
 This example has been tested on the following Zephyr targets:
-* [apollo4p_blue_kxr_evb](https://docs.zephyrproject.org/latest/boards/ambiq/apollo4p_blue_kxr_evb/doc/index.html)
 * [nrf52dk_nrf52832](https://docs.zephyrproject.org/latest/boards/nordic/nrf52dk/doc/index.html)
 * [nrf52840dk_nrf52840](https://docs.zephyrproject.org/latest/boards/nordic/nrf52840dk/doc/index.html)
 * [nrf5340dk_nrf5340_cpuapp](https://docs.zephyrproject.org/latest/boards/nordic/nrf5340dk/doc/index.html)
 * [nrf9160dk_nrf9160](https://docs.zephyrproject.org/latest/boards/nordic/nrf9160dk/doc/index.html)
 * [nrf54l15dk/nrf54l15/cpuapp](https://docs.zephyrproject.org/latest/boards/nordic/nrf54l15dk/doc/index.html)
-  * NCS 3.0.0: `west build -b nrf54l15dk/nrf54l15/cpuapp`
+  * NCS 3.0.0 (mandatory)
+* [apollo4p_blue_kxr_evb](https://docs.zephyrproject.org/latest/boards/ambiq/apollo4p_blue_kxr_evb/doc/index.html)
+  * not suted for builds with included `./Dockerfile`
 
 You can also run the example with Nordic nRF Connect SDK and the following boards:
 * [thingy91_nrf9160_ns](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/working_with_nrf/nrf91/thingy91.html#building-and-programming-from-the-source-code)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,9 +25,12 @@ int main() {
     // This is needed so that output of printf is output immediately without buffering
     setvbuf(stdout, NULL, _IONBF, 0);
 
+
+#if (KERNEL_VERSION_MAJOR < 3)
 #ifdef CONFIG_SOC_NRF5340_CPUAPP // this comes from Zephyr
-    // Switch CPU core clock to 128 MHz
+    // Switch CPU core clock to 128 MHz (only for NCS < 3.0.0)
     nrfx_clock_divider_set(NRF_CLOCK_DOMAIN_HFCLK, NRF_CLOCK_HFCLK_DIV_1);
+#endif
 #endif
 
     printk("Edge Impulse standalone inferencing (Zephyr)\n");


### PR DESCRIPTION
* add nRF54L15dk to README
* tested all boards with NCS 3.0.0
* updated main for nRF5340dk (default clk is 128)
* updated Docker file